### PR TITLE
Debug, release, and push to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ app/release
 .ignored
 app/*.txt
 .kotlin/
+android-sdk

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -157,8 +157,8 @@
     <string name="amp2html_local_cache_explainer">تخزين النسخ المستردة بخلاف AMP لصفحات الويب محليًا</string>
     <string name="amp2html_external_service_explainer">محاولة الحصول على إصدار صفحة غير AMP باستخدام واجهة برمجة تطبيقات منشورة على supabase.com (<annotation url-id="supabase-privacy">سياسة الخصوصية</annotation>)</string>
     <string name="follow_only_known_trackers_explainer">حاول فقط اتباع عمليات إعادة التوجيه عندما يكون من المعروف أن المضيف متتبع / معيد توجيه. إذا تم تمكين \"متابعة عمليات إعادة التوجيه عبر خدمة خارجية\" ، فسيتم تمكين هذا دائمًا</string>
-    <string name="resolved_via">%s تم حلها عبر %s</string>
-    <string name="resolve_failed">%s فشل: %s</string>
+    <string name="resolved_via">%1$s تم حلها عبر %2$s</string>
+    <string name="resolve_failed">%1$s فشل: %2$s</string>
     <string name="usage_stats_sorting_explainer">قم بتضمين إحصائيات استخدام نظام Android في خوارزمية الفرز. يتم طلب الإذن عند التبديل الأول.</string>
     <string name="enable_request_private_browsing_button_explainer">يعرض زرا بجوار المتصفحات يفتح عنوان URL الذي تم النقر عليه في وضع التصفح الخاص. المتصفحات المدعومة: %s</string>
     <string name="use_unified_preferred_browser_explainer">يؤدي تمكين هذا إلى تطبيق الإعدادات أدناه على كل من التعامل مع الروابط العادية وداخل التطبيق. استخدم الأزرار أدناه للتبديل بين الوضع العادي والوضع داخل التطبيق عند تعطيله.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -105,7 +105,7 @@
     <string name="light">Светла</string>
     <string name="dark">Тъмна</string>
     <string name="fastfoward_rules">Използване на правила на FastForward</string>
-    <string name="resolved_via">%s получено от %s</string>
+    <string name="resolved_via">%1$s получено от %2$s</string>
     <string name="instance">Екземпляр</string>
     <string name="add">Добавяне</string>
     <string name="in_app_browser">Вграден в приложението браузър</string>
@@ -176,7 +176,7 @@
     <string name="advanced">Разширени</string>
     <string name="shizuku_explainer_short">Директно взаимодейства със системните ППИ</string>
     <string name="mastodon_redirect">MastodonRedirect</string>
-    <string name="resolve_failed">%s е неуспешно: %s</string>
+    <string name="resolve_failed">%1$s е неуспешно: %2$s</string>
     <string name="pretend_to_be_app">Прехващане на заявки от приложения</string>
     <string name="configure">Настройки</string>
     <string name="general">Разни</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -38,7 +38,7 @@
     <string name="follow_redirects_external_service">Následovat přesměrování skrze externí službu</string>
     <string name="follow_redirects_local_cache">Povolit místní mezipaměť přesměrování</string>
     <string name="follow_redirects_local_cache_explainer">Lokálně ukládat výsledné adresy přesměrování</string>
-    <string name="resolved_via">%s vyřešeno pomocí %s</string>
+    <string name="resolved_via">%1$s vyřešeno pomocí %2$s</string>
     <string name="redirect_resolve_type_local">místního překladače</string>
     <string name="lib_redirect">LibRedirect</string>
     <string name="instance">Instance</string>
@@ -140,7 +140,7 @@
     <string name="donate_explainer_crypto">Při přispívání kryptoměnou pošlete e-mail na adresu <annotation url="mailto:1fexd@420blaze.it">1fexd@420blaze.it</annotation>.</string>
     <string name="download_started">Stahování spuštěno</string>
     <string name="request_timeout_explainer">Určuje, kolik sekund bude aplikace LinkSheet čekat na navázání spojení. Nastavením na 0 se časový limit vypne, to ale nedoporučujeme.</string>
-    <string name="resolve_failed">%s selhalo: %s</string>
+    <string name="resolve_failed">%1$s selhalo: %2$s</string>
     <string name="discord">Discord</string>
     <string name="join">Připojit se</string>
     <string name="misc_settings">Různé</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -64,7 +64,7 @@
     <string name="no_apps_found">Keine Apps gefunden.</string>
     <string name="normal">Normal</string>
     <string name="request_timeout_explainer">Definiert, wie viele Sekunden LinkSheet für die Herstellung einer Verbindung warten wird. Der Wert 0 deaktiviert die Zeitüberschreitung, dies wird aber nicht empfohlen.</string>
-    <string name="resolve_failed">%s fehlgeschlagen: %s</string>
+    <string name="resolve_failed">%1$s fehlgeschlagen: %2$s</string>
     <string name="export">Exportieren</string>
     <string name="no_browsers_found">Keine Browser gefunden.</string>
     <string name="export_log">Protokoll exportieren</string>
@@ -178,7 +178,7 @@
     <string name="open_link_with" translatable="false">OpenLinkWith</string>
     <string name="select_an_app">App auswählen</string>
     <string name="github_workflow_run_id">Build-Workflow-ID:</string>
-    <string name="resolved_via">%s aufgelöst über %s</string>
+    <string name="resolved_via">%1$s aufgelöst über %2$s</string>
     <string name="instance_not_available_anymore">Instanz ist nicht mehr verfügbar!</string>
     <string name="donate_crypto">Mit Krypto spenden</string>
     <string name="follow_redirects_explainer">Automatisch allen Weiterleitungen folgen, bevor das untere Fenster geöffnet wird. Dies kann <annotation url-id="privacy-follow-redirects">Auswirkungen auf die Privatsphäre</annotation> haben</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,7 +74,7 @@
     <string name="show_linksheet_referrer">Mostrar referencias de LinkSheet</string>
     <string name="url_copied">Enlace copiado al portapapeles</string>
     <string name="copy_url">Copiar enlace</string>
-    <string name="resolve_failed">%s fallido: %s</string>
+    <string name="resolve_failed">%1$s fallido: %2$s</string>
     <string name="none">Ninguno</string>
     <string name="export">Exportar</string>
     <string name="hide_after_copying">Ocultar automáticamente después de una acción</string>
@@ -142,7 +142,7 @@
     <string name="open_link_with" translatable="false">OpenLinkWith</string>
     <string name="select_an_app">Seleccionar una aplicación</string>
     <string name="github_workflow_run_id"><b>ID de flujo de trabajo:</b> <font face="monospace">%s</font></string>
-    <string name="resolved_via">%s vía resuelta %s</string>
+    <string name="resolved_via">%1$s vía resuelta %2$s</string>
     <string name="instance_not_available_anymore">¡Esta instancia ya no está disponible!</string>
     <string name="open_with_linksheet">Abrir con LinkSheet</string>
     <string name="in_app_browser">Navegador en aplicación</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,7 +125,7 @@
     <string name="no_log_entries">Cette session ne contient aucun journal.</string>
     <string name="download_started">Téléchargement démarré</string>
     <string name="request_timeout">Délai de requête</string>
-    <string name="resolve_failed">%s échoué : %s</string>
+    <string name="resolve_failed">%1$s échoué : %2$s</string>
     <string name="no_browsers_found">Aucun navigateur n\'a été trouvé.</string>
     <string name="no_apps_found">Aucune application trouvée.</string>
     <string name="export">Exporter</string>
@@ -157,7 +157,7 @@
     <string name="fastfoward_rules">Utiliser les règles FastForward</string>
     <string name="follow_redirects_local_cache">Activer le cache de redirection local</string>
     <string name="follow_redirects_local_cache_explainer">Mettre en cache localement le résultat des redirections</string>
-    <string name="resolved_via">%s résolu via %s</string>
+    <string name="resolved_via">%1$s résolu via %2$s</string>
     <string name="preview_url">Aperçu de l\'url</string>
     <string name="preview_url_explainer">Affiche l\'url cliquée (une fois qu\'elle a été traitée)</string>
     <string name="amp2html_local_cache">Activer le cache local Amp2Html</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -87,7 +87,7 @@
     <string name="fastfoward_rules">Gunakan aturan FastForward</string>
     <string name="follow_redirects_local_cache">Aktifkan singgahan (cache) pengalihan lokal</string>
     <string name="follow_redirects_local_cache_explainer">Singgahkan (cache) hasil pengalihan secara lokal</string>
-    <string name="resolved_via">%s diselesaikan melalui %s</string>
+    <string name="resolved_via">%1$s diselesaikan melalui %2$s</string>
     <string name="redirect_resolve_type_remote">peladen jarak jauh</string>
     <string name="redirect_resolve_type_local">penyelesai lokal</string>
     <string name="enable_libredirect">Aktifkan LibRedirect</string>
@@ -148,7 +148,7 @@
     <string name="log_viewer">Penampil log</string>
     <string name="request_timeout">Batas waktu permintaan</string>
     <string name="request_timeout_explainer">Menentukan berapa detik LinkSheet akan menunggu hingga koneksi terbentuk. Menyetel nilainya ke 0 akan menonaktifkan batas waktu, tetapi ini tidak direkomendasikan.</string>
-    <string name="resolve_failed">%s gagal: %s</string>
+    <string name="resolve_failed">%1$s gagal: %2$s</string>
     <string name="no_browsers_found">Tidak ditemukan peramban yang ada.</string>
     <string name="no_apps_found">Tidak ditemukan aplikasi yang ada.</string>
     <string name="export">Ekspor</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -96,7 +96,7 @@
     <string name="follow_only_known_trackers">Segui solo i tracker noti</string>
     <string name="amp2html">Amp2Html</string>
     <string name="loading_link">Caricamento link…</string>
-    <string name="resolved_via">%s risolto tramite %s</string>
+    <string name="resolved_via">%1$s risolto tramite %2$s</string>
     <string name="redirect_resolve_type_remote">server remoto</string>
     <string name="redirect_resolve_type_local">risolutore locale</string>
     <string name="normal">Normale</string>
@@ -164,7 +164,7 @@
     <string name="logs_explainer">Consulta i log</string>
     <string name="log_viewer">Visualizzatore log</string>
     <string name="no_log_entries">Non ci sono log riferiti a questa sessione.</string>
-    <string name="resolve_failed">%s fallito: %s</string>
+    <string name="resolve_failed">%1$s fallito: %2$s</string>
     <string name="disable_all">Disabilita tutto</string>
     <string name="app_browsers_subtitle">App preferite, impostazioni del browser</string>
     <string name="include_fingerprint">Includi il fingerprint o identificatore univoco del dispositivo ﹙consigliato﹚</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -133,7 +133,7 @@
     <string name="follow_redirects_short">リダイレクト</string>
     <string name="unknown_host">%s はブロックされているか存在しません</string>
     <string name="fastfoward_rules_explainer">実験的な <annotation url-id="fastforward-github">FastForward</annotation> ルールの統合を使用する (リンクからリダイレクトを抽出することで、一部のウェブサイトのリダイレクトをバイパスする)</string>
-    <string name="resolved_via">%s は %s 経由で解決されました</string>
+    <string name="resolved_via">%1$s は %2$s 経由で解決されました</string>
     <string name="dont_show_filtered_item_explainer">最後に使用したアプリを提案する上部の項目を表示しない</string>
     <string name="downloader_url_mime_type_explainer">URLの末尾にファイル拡張子（例：\".jpg\"）があるかどうかをチェックします。拡張子がある場合は、ダウンロードしたファイルにこのタイプが使われます。</string>
     <string name="disable_in_selected">強制無効化…</string>
@@ -247,7 +247,7 @@
     <string name="no_libredirect_services">LibRedirectのサービスは見つかりませんでした！</string>
     <string name="download_started">ダウンロードが開始されました</string>
     <string name="request_timeout">リクエストタイムアウト</string>
-    <string name="resolve_failed">%s 失敗: %s</string>
+    <string name="resolve_failed">%1$s 失敗: %2$s</string>
     <string name="export_log">ログをエクスポート</string>
     <string name="include_settings">設定を含める（推奨）</string>
     <string name="include_fingerprint">デバイスのフィンガープリントを含める（推奨）</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -43,7 +43,7 @@
     <string name="system">Systeeminstelling volgen</string>
     <string name="follow_redirects_local_cache">Lokale omleidingscache inschakelen</string>
     <string name="follow_redirects_local_cache_explainer">Sla de resultaten van omleidingen lokaal op</string>
-    <string name="resolved_via">%s verwerkt via %s</string>
+    <string name="resolved_via">%1$s verwerkt via %2$s</string>
     <string name="redirect_resolve_type_local">lokale verwerker</string>
     <string name="instance">Server</string>
     <string name="add">Toevoegen</string>
@@ -56,7 +56,7 @@
     <string name="debug_explainer">App-logs, geverifieerde linkverwerkers resetten</string>
     <string name="no_libredirect_services">Geen LibRedirect-diensten gevonden!</string>
     <string name="request_timeout">Time-out verbindingen</string>
-    <string name="resolve_failed">%s mislukt: %s</string>
+    <string name="resolve_failed">%1$s mislukt: %2$s</string>
     <string name="redact_log">Gevoelige informatie afschermen (aanbevolen, uitschakelen kan pakketnamen en hostnamen lekken)</string>
     <string name="copy_to_clipboard">Naar klembord kopiëren</string>
     <string name="generic__button_text_copy_clipboard">Naar klembord kopiëren</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -74,7 +74,7 @@
     <string name="show_linksheet_referrer">ਲਿੰਕਸ਼ੀਟ ਰੈਫਰਰ ਦਿਖਾਓ</string>
     <string name="url_copied">URL ਨੂੰ ਕਲਿੱਪਬੋਰਡ ਵਿੱਚ ਕਾਪੀ ਕੀਤਾ ਗਿਆ</string>
     <string name="copy_url">URL ਕਾਪੀ ਕਰੋ</string>
-    <string name="resolve_failed">%s ਅਸਫਲ: %s</string>
+    <string name="resolve_failed">%1$s ਅਸਫਲ: %2$s</string>
     <string name="none">ਕੋਈ ਵੀ ਨਹੀਂ</string>
     <string name="export">ਐਕਸਪੋਰਟ ਕਰੋ</string>
     <string name="hide_after_copying">ਕਾਪੀ ਕਰਨ ਤੋਂ ਬਾਅਦ ਓਹਲੇ ਕਰੋ</string>
@@ -142,7 +142,7 @@
     <string name="open_link_with" translatable="false">OpenLinkWith</string>
     <string name="select_an_app">ਇੱਕ ਐਪ ਚੁਣੋ</string>
     <string name="github_workflow_run_id">ਬਿਲਡ ਵਰਕਫਲੋ ਆਈਡੀ:</string>
-    <string name="resolved_via">%s ਨੂੰ %s ਰਾਹੀਂ ਰਿਜ਼ੌਲਵ ਕੀਤਾ</string>
+    <string name="resolved_via">%1$s ਨੂੰ %2$s ਰਾਹੀਂ ਰਿਜ਼ੌਲਵ ਕੀਤਾ</string>
     <string name="instance_not_available_anymore">ਇੰਸਟੈਂਸ ਹੁਣ ਉਪਲਬਧ ਨਹੀਂ ਹੈ!</string>
     <string name="open_with_linksheet">ਲਿੰਕਸ਼ੀਟ ਨਾਲ ਖੋਲ੍ਹੋ</string>
     <string name="in_app_browser">ਇਨ-ਐਪ ਬ੍ਰਾਊਜ਼ਰ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -157,8 +157,8 @@
     <string name="amp2html_external_service">Uzyskaj wersję stron bez AMP</string>
     <string name="amp2html_external_service_explainer">Preferuj bezpośrednie strony zamiast wersji AMP przy użyciu API z supabase.com (<annotation url-id="supabase-privacy">Polityka prywatności</annotation>)</string>
     <string name="follow_only_known_trackers_explainer">Próbuj śledzić przekierowania tylko wtedy, gdy host jest znany jako tracker lub przekierowanie. Jeśli opcja „Śledź przekierowania przez usługę zewnętrzną” jest włączona, ta opcja będzie zawsze aktywna</string>
-    <string name="resolved_via">%s rozwiązano przez %s</string>
-    <string name="resolve_failed">%s nie powiodło się: %s</string>
+    <string name="resolved_via">%1$s rozwiązano przez %2$s</string>
+    <string name="resolve_failed">%1$s nie powiodło się: %2$s</string>
     <string name="enable_request_private_browsing_button_explainer">Wyświetla przycisk obok przeglądarek, który otwiera kliknięty adres URL w trybie przeglądania prywatnego. Obsługiwane przeglądarki: %s</string>
     <string name="usage_stats_sorting_explainer">Uwzględnij statystyki użycia systemu Android w algorytmie sortowania. Żądane jest uprawnienie przy pierwszym przełączeniu.</string>
     <string name="use_unified_preferred_browser_explainer">Po włączeniu zostaną zastosowane poniższe ustawienia do obsługi linków w trybach normalnym i w aplikacji. Jeśli opcja jest wyłączona, używaj poniższych przycisków, aby przełączać między tymi trybami.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -100,7 +100,7 @@
     <string name="fastfoward_rules_explainer">Usar a integração experimental <annotation url-id="fastforward-github">FastForward</annotation> (ignore os redirecionamentos de alguns hosts extraindo o redirecionamento do link)</string>
     <string name="follow_redirects_local_cache">Ativar o cache de redirecionamento local</string>
     <string name="follow_redirects_local_cache_explainer">Armazenar em cache o resultado dos redirecionamentos localmente</string>
-    <string name="resolved_via">%s resolvido via %s</string>
+    <string name="resolved_via">%1$s resolvido via %2$s</string>
     <string name="dont_show_filtered_item">Não mostre a seção \"último app escolhido\"</string>
     <string name="dont_show_filtered_item_explainer">Não mostrar a seção superior que sugere o último aplicativo usado para o host clicado</string>
     <string name="preview_url_explainer">Mostra o URL clicado (após ter sido processado)</string>
@@ -158,7 +158,7 @@
     <string name="log_files">Sessões anteriores</string>
     <string name="services">Serviços</string>
     <string name="current_session">Sessão atual</string>
-    <string name="resolve_failed">%s falhou: %s</string>
+    <string name="resolve_failed">%1$s falhou: %2$s</string>
     <string name="no_apps_found">Nenhum app foi encontrado.</string>
     <string name="enable_request_private_browsing_button">Ativar o botão \"Solicitar navegação privada\"</string>
     <string name="enable_request_private_browsing_button_explainer">Exibe um botão ao lado dos navegadores que abre o URL clicado no modo de navegação privada. Navegadores compatíveis: %s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -83,7 +83,7 @@
     <string name="fastfoward_rules_explainer">Deneysel <annotation url-id="fastforward-github">FastForward</annotation> kural entegrasyonunu kullanın (bağlantıdan yönlendirmeyi çıkararak bazı ana bilgisayarların yönlendirmelerini atlatın)</string>
     <string name="follow_redirects_local_cache">Yerel yönlendirme önbelleğini etkinleştir</string>
     <string name="follow_redirects_local_cache_explainer">Yönlendirmelerin sonucunu yerel olarak önbelleğe al</string>
-    <string name="resolved_via">%s %s aracılığıyla çözüldü</string>
+    <string name="resolved_via">%1$s %2$s aracılığıyla çözümlendi</string>
     <string name="redirect_resolve_type_remote">uzak sunucu</string>
     <string name="redirect_resolve_type_local">yerel çözücü</string>
     <string name="enable_libredirect">LibRedirect\'i etkinleştir</string>
@@ -117,7 +117,7 @@
     <string name="no_log_entries">Bu oturum herhangi bir günlük içermiyor.</string>
     <string name="download_started">İndirme başladı</string>
     <string name="request_timeout">İstek zaman aşımı</string>
-    <string name="resolve_failed">%s başarısız oldu: %s</string>
+    <string name="resolve_failed">%1$s başarısız oldu: %2$s</string>
     <string name="request_timeout_explainer">LinkSheet\'in bir bağlantının kurulması için kaç saniye bekleyeceğini belirler. Bunu 0 yapmak zaman aşımını devre dışı bırakır, ancak bu önerilmez.</string>
     <string name="no_browsers_found">Tarayıcı bulunamadı.</string>
     <string name="export">Dışa aktar</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -53,7 +53,7 @@
     <string name="request_timeout_explainer">Xác định số giây LinkSheet sẽ đợi để thiết lập kết nối. Đặt giá trị này thành 0 sẽ tắt thời gian chờ nhưng điều này không được khuyến khích.</string>
     <string name="url_copied">URL đã được sao chép vào clipboard</string>
     <string name="copy_url">Sao chép liên kết</string>
-    <string name="resolve_failed">%s thất bại: %s</string>
+    <string name="resolve_failed">%1$s thất bại: %2$s</string>
     <string name="none">Không có</string>
     <string name="export">Xuất</string>
     <string name="hide_after_copying">Tự động ẩn khi hành động</string>
@@ -108,7 +108,7 @@
     <string name="open_link_with" translatable="false">OpenLinkWith</string>
     <string name="select_an_app">Chọn một ứng dụng</string>
     <string name="github_workflow_run_id"><b>ID quy trình làm việc:</b> <font face="monospace">%s</font></string>
-    <string name="resolved_via">%s giải quyết qua %s</string>
+    <string name="resolved_via">%1$s giải quyết qua %2$s</string>
     <string name="open_with_linksheet">Mở bằng LinkSheet</string>
     <string name="in_app_browser">Trình duyệt trong ứng dụng</string>
     <string name="links">Liên kết</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -252,7 +252,7 @@
     <string name="amp2html_local_cache">啟用本機 Amp2Html 快取</string>
     <string name="select_app">選取應用程式</string>
     <string name="settings_shortcuts__subtitle_default_browser">前往「預設瀏覽器應用程式」設定頁面</string>
-    <string name="resolved_via">已解析 %s (透過 %s)</string>
+    <string name="resolved_via">已解析 %1$s (透過 %2$s)</string>
     <string name="home__clipboard_card_source">來自剪貼簿</string>
     <string name="resolve_event__idle">閒置中</string>
     <string name="onboarding_1_card_title">預設瀏覽器</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -153,7 +153,7 @@
     <string name="success">成功</string>
     <string name="request_timeout_explainer">定义 LinkSheet 等待建立连接的秒数。将此设置为 0 将禁用超时（不建议）。</string>
     <string name="configure">配置</string>
-    <string name="resolve_failed">%s 失败：%s</string>
+    <string name="resolve_failed">%1$s 失败：%2$s</string>
     <string name="export">导出</string>
     <string name="no_browsers_found">未找到浏览器。</string>
     <string name="export_log">导出日志</string>
@@ -186,7 +186,7 @@
     <string name="dev">开发者</string>
     <string name="request_private_browsing">隐私</string>
     <string name="import_explainer">从文件导入以前的导出</string>
-    <string name="resolved_via">%s 由%s 解析</string>
+    <string name="resolved_via">%1$s 由 %2$s 解析</string>
     <string name="instance_not_available_anymore">实例已经不再可用！</string>
     <string name="shizuku_integration_not_setup_explainer">LinkSheet 可在不使用 Shizuku 的情况下工作，但仍然建议使用 Shizuku。点击此处安装。</string>
     <string name="export_import_settings_explainer">导出当前设置或导入以前导出的设置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
     <string name="fastfoward_rules_explainer">Use experimental <annotation url-id="fastforward-github">FastForward</annotation> rule integration (bypass redirects of some hosts by extracting redirect from link)</string>
     <string name="follow_redirects_local_cache">Enable local redirect cache</string>
     <string name="follow_redirects_local_cache_explainer">Cache the result of redirects locally</string>
-    <string name="resolved_via">%s resolved via %s</string>
+    <string name="resolved_via">%1$s resolved via %2$s</string>
     <string name="redirect_resolve_type_local_cache">local cache</string>
     <string name="redirect_resolve_type_remote">remote server</string>
     <string name="redirect_resolve_type_local">local resolver</string>
@@ -143,7 +143,7 @@
     <string name="download_started">Download started</string>
     <string name="request_timeout">Request timeout</string>
     <string name="request_timeout_explainer">Defines how many seconds LinkSheet will wait for a connection to be established. Setting this to 0 disables the timeout, but this is not recommended.</string>
-    <string name="resolve_failed">%s failed: %s</string>
+    <string name="resolve_failed">%1$s failed: %2$s</string>
     <string name="no_browsers_found">No browsers found.</string>
     <string name="no_apps_found">No apps found.</string>
     <string name="export">Export</string>


### PR DESCRIPTION
Add `/android-sdk` to `.gitignore` and normalize string placeholders to positional specifiers across locales.

The string placeholder changes fix resource formatting warnings that could lead to build failures in release environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-59068840-194a-4e19-9724-16f8667a188b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59068840-194a-4e19-9724-16f8667a188b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

